### PR TITLE
GB `:unofficial_names` tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Countries
 
-[![Build Status](https://travis-ci.org/SebastianSzturo/countries.svg?branch=master)](https://travis-ci.org/SebastianSzturo/countries)
-[![Module Version](https://img.shields.io/hexpm/v/countries.svg)](https://hex.pm/packages/countries)
-[![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/countries/)
-[![Total Download](https://img.shields.io/hexpm/dt/countries.svg)](https://hex.pm/packages/countries)
-[![License](https://img.shields.io/hexpm/l/countries.svg)](https://github.com/yyy/countries/blob/master/LICENSE)
-[![Last Updated](https://img.shields.io/github/last-commit/SebastianSzturo/countries.svg)](https://github.com/SebastianSzturo/countries/commits/master)
-
-Countries is a collection of all sorts of useful information for every country in the [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) standard.
+Countries is a collection of all sorts of useful information for every country
+in the [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) standard.
 It is based on the data from the Ruby Gem [Countries](https://github.com/hexorx/countries).
+
+## Forked
+
+This is a fork of the original repo, which makes a minor change to the ordering
+of the `:unoffical_names` list for the GB data; which adheres to DICE's
+preference for 'United Kingdom' over 'The United Kingdom'.
+
+Additionally, it has been updated to compile without warnings on Elixir 1.18
+and the dependencies have been updated to the latest versions.
 
 ## Installation
 
@@ -29,7 +32,7 @@ Find country by attribute:
 ```elixir
 country = Countries.filter_by(:alpha2, "DE")
 # [%Countries.Country{alpha2: 'DE', alpha3: 'DEU', continent: 'Europe',
-#	 country_code: '49', currency: 'EUR', ...]
+#  country_code: '49', currency: 'EUR', ...]
 
 countries = Countries.filter_by(:region, "Europe")
 Enum.count(countries)

--- a/priv/data/countries/GB.yaml
+++ b/priv/data/countries/GB.yaml
@@ -37,8 +37,8 @@ GB:
     parking: 
   postal_code: true
   unofficial_names:
-  - The United Kingdom
   - United Kingdom
+  - The United Kingdom
   - Vereinigtes Königreich
   - Royaume-Uni
   - Reino Unido


### PR DESCRIPTION
We have code that pulls the first item from this list, but our preference is "United Kingdom", not "The United Kingdom".